### PR TITLE
Fix isSuperCall CoffeeScript > 1.10 support

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -14,7 +14,9 @@ class FieldInfo
     @value = binding.value
 
 isSuperCall = (expr) ->
-  (expr.constructor.name is 'Call') and expr.isSuper
+  expr.constructor.name is 'SuperCall' or
+    # CoffeeScript <1.10.0 support
+    (expr.constructor.name is 'Call') and (expr.isSuper? and expr.isSuper)
 
 module.exports = class EnsureSuper
 


### PR DESCRIPTION
the linter didn't work because CoffeeScript > 1.10 uses 'SuperCall'
to check for super calls instead of isSuper.